### PR TITLE
Fix broken display for literals with non-HTTP datatype IRI

### DIFF
--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -974,21 +974,24 @@ function getFormattedResultEntry(str, maxLength, column = undefined) {
   // it's terribly inefficient.
   if (pos > 0) {
     cpy = cpy.replace(/ /g, '_');
-    link = cpy.substring(pos).match(/(https?:\/\/[a-zA-Z0-9.:%/#\?_-]+)/g)[0];
-    columnHTML = $($('#resTable').find('th')[column + 1]);
-    content = '<a href="' + link + '" target="_blank"><i class="glyphicon glyphicon-list-alt" data-toggle="tooltip" title="' + link + '"></i></a> ';
-    if (columnHTML.html().indexOf(content) < 0) {
-      columnHTML.html(content + columnHTML.html());
-    }
-    // If the type is int or integer or if the type is decimal yet the number is
-    // an integer, display the number with thousand separators and mark it as
-    // right-aligned.
-    const typeIsInteger = link.endsWith("int") || link.endsWith("integer");
-    const typeIsDecimalButNumberIsInteger = link.endsWith("decimal") && str.match(/^\d+$/);
-    if (typeIsInteger || typeIsDecimalButNumberIsInteger) {
-      if (!var_name.endsWith("year")) {
-        str = formatInteger(str);
-        rightAlign = true;
+    const linkMatch = cpy.substring(pos).match(/(https?:\/\/[a-zA-Z0-9.:%/#\?_-]+)/g);
+    if (linkMatch) {
+      const link = linkMatch[0];
+      const columnHTML = $($('#resTable').find('th')[column + 1]);
+      const content = '<a href="' + link + '" target="_blank"><i class="glyphicon glyphicon-list-alt" data-toggle="tooltip" title="' + link + '"></i></a> ';
+      if (columnHTML.html().indexOf(content) < 0) {
+        columnHTML.html(content + columnHTML.html());
+      }
+      // If the type is int or integer or if the type is decimal yet the number is
+      // an integer, display the number with thousand separators and mark it as
+      // right-aligned.
+      const typeIsInteger = link.endsWith("int") || link.endsWith("integer");
+      const typeIsDecimalButNumberIsInteger = link.endsWith("decimal") && str.match(/^\d+$/);
+      if (typeIsInteger || typeIsDecimalButNumberIsInteger) {
+        if (!var_name.endsWith("year")) {
+          str = formatInteger(str);
+          rightAlign = true;
+        }
       }
     }
 


### PR DESCRIPTION
This fixes https://github.com/ad-freiburg/qlever/issues/2805, an issue that occurs when parsing datatypes of IRIs that don't start with HTTP (or don't match the regex in any other shape or form). Minimal reproducer:
```sparql
SELECT * {
  VALUES ?x { "2026-01-01"^^<xsd:dateTime> }
}
```